### PR TITLE
feat: add `offset-format` placeholder modifier

### DIFF
--- a/docs/docs/reference/enum-types.md
+++ b/docs/docs/reference/enum-types.md
@@ -74,6 +74,17 @@ The type of meta information used for context substitution placeholders.
 | `string` | A string data type. |
 | `variable` | A custom configuration variable. |
 
+## PlaceholderModifierType
+
+The modifiers for placeholder expressions.
+
+| Value | Description |
+|-------|-------------|
+| `format` | Use `${<key>:format:<format>}` to format the date/time using a [date-fns format strings](https://date-fns.org/docs/format). |
+| `join` | Use `${<key>:join:<string>}` to join the values of an array (default: `,`). |
+| `` | No modifier |
+| `offset-format` | Use `${<key>:offset-format:<offset>:<format>}` to calculate the date/time offset using a [parse-duration format string](https://github.com/jkroso/parse-duration#parsestr-formatms) and then format the resulting date/time using a [date-fns format strings](https://date-fns.org/docs/format). |
+
 ## PlaceholderType
 
 The type of a placeholder.

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "ajv": "^8.12.0",
         "class-transformer": "^0.5.1",
         "date-fns-tz": "^2.0.0",
+        "parse-duration": "^1.1.0",
         "reflect-metadata": "^0.1.13",
         "type-fest": "^4.3.1"
       },
@@ -13544,6 +13545,11 @@
       "resolved": "https://registry.npmjs.org/parse-cache-control/-/parse-cache-control-1.0.1.tgz",
       "integrity": "sha512-60zvsJReQPX5/QP0Kzfd/VrpjScIQ7SHBW6bFCYfEP+fp0Eppr1SHhIO5nd1PjZtvclzSzES9D/p5nFJurwfWg==",
       "dev": true
+    },
+    "node_modules/parse-duration": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/parse-duration/-/parse-duration-1.1.0.tgz",
+      "integrity": "sha512-z6t9dvSJYaPoQq7quMzdEagSFtpGu+utzHqqxmpVWNNZRIXnvqyCvn9XsTdh7c/w0Bqmdz3RB3YnRaKtpRtEXQ=="
     },
     "node_modules/parse-json": {
       "version": "5.2.0",

--- a/package.json
+++ b/package.json
@@ -118,6 +118,7 @@
     "ajv": "^8.12.0",
     "class-transformer": "^0.5.1",
     "date-fns-tz": "^2.0.0",
+    "parse-duration": "^1.1.0",
     "reflect-metadata": "^0.1.13",
     "type-fest": "^4.3.1"
   },

--- a/src/lib/Context.ts
+++ b/src/lib/Context.ts
@@ -189,3 +189,10 @@ export function newProcessingResult(): ProcessingResult {
     status: ProcessingStatus.OK,
   }
 }
+
+export type Context =
+  | EnvContext
+  | ProcessingContext
+  | ThreadContext
+  | MessageContext
+  | AttachmentContext

--- a/src/lib/utils/PatternUtil.spec.ts
+++ b/src/lib/utils/PatternUtil.spec.ts
@@ -3,13 +3,13 @@ import { ContextMocks } from "../../test/mocks/ContextMocks"
 import { EXISTING_FOLDER_NAME } from "../../test/mocks/GDriveMocks"
 import { GMailData } from "../../test/mocks/GMailMocks"
 import {
+  fakedSystemDateTimeString,
   MockFactory,
   Mocks,
-  fakedSystemTime,
 } from "../../test/mocks/MockFactory"
-import { RunMode } from "../Context"
 import { Config, newConfig } from "../config/Config"
 import { MarkProcessedMethod } from "../config/SettingsConfig"
+import { RunMode } from "../Context"
 import { PatternUtil } from "./PatternUtil"
 
 let mocks: Mocks
@@ -264,8 +264,8 @@ describe("Substitutions", () => {
     expect(actual).toMatchObject({
       envRunMode: RunMode.DANGEROUS,
       envTimeZone: "UTC",
-      dateNow: fakedSystemTime,
-      timerStartTime: fakedSystemTime,
+      dateNow: fakedSystemDateTimeString,
+      timerStartTime: fakedSystemDateTimeString,
     })
   })
   it("should substitute global variables", () => {
@@ -422,7 +422,26 @@ describe("Placeholder Handling", () => {
       "${message.id},${message.replyTo},${message.subject},${message.to},${date.now:format:yyyy-MM-dd HH:mm:ss}"
     const actual = PatternUtil.substitute(mocks.attachmentContext, s)
     expect(actual).toEqual(
-      `message-bcc@example.com,message-cc@example.com,${fakedSystemTime},message-from@example.com,message-id,message-reply-to@example.com,Message Subject 1,message-to@example.com,${fakedSystemTime}`,
+      `message-bcc@example.com,message-cc@example.com,${fakedSystemDateTimeString},message-from@example.com,message-id,message-reply-to@example.com,Message Subject 1,message-to@example.com,${fakedSystemDateTimeString}`,
     )
+  })
+})
+describe("Date Placeholder", () => {
+  it("should handle modifier 'format'", () => {
+    expect(
+      PatternUtil.valueToString(
+        mocks.envContext,
+        "date.now:format:yyyy-MM-dd HH:mm:ss",
+      ),
+    ).toEqual(fakedSystemDateTimeString)
+  })
+  it("should handle modifier 'offset-format'", () => {
+    const offset = "-2d"
+    expect(
+      PatternUtil.valueToString(
+        mocks.envContext,
+        `date.now:offset-format:${offset}:yyyy-MM-dd HH:mm:ss`,
+      ),
+    ).toEqual("2023-06-24 09:00:00")
   })
 })

--- a/src/test/mocks/MockFactory.ts
+++ b/src/test/mocks/MockFactory.ts
@@ -16,8 +16,9 @@ import { GDriveMocks, LOGSHEET_FILE_ID } from "./GDriveMocks"
 import { GMailData, GMailMocks, IndexType } from "./GMailMocks"
 import { SpreadsheetMocks } from "./SpreadsheetMocks"
 
-export const fakedSystemTime = "2023-06-26 09:00:00"
-jest.useFakeTimers({ now: new Date(fakedSystemTime + "Z") })
+export const fakedSystemDateTimeString = "2023-06-26 09:00:00"
+export const fakedSystemDateTime = new Date(fakedSystemDateTimeString + "Z")
+jest.useFakeTimers({ now: fakedSystemDateTime })
 
 class EnvMocks {
   public attachment: MockProxy<GoogleAppsScript.Gmail.GmailAttachment> =


### PR DESCRIPTION
# Description

Adds the date placeholder modifier `offset-format` to format the date using an arbitrary offset date/time.
The offset can be specified using a [parse-duration format string](https://github.com/jkroso/parse-duration#parsestr-formatms).

Example usage: `${message.date:offset-format:-2d:yyyy-MM-dd HH:mm:ss}`

This results in a formatted date/time two days before the message date.

Fixes #135

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How has this been tested?

- [x] Added a unit test to `PaternUtil.spec.ts`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
