### PR TITLE
feat: add regex modifier flags support

### DIFF
--- a/docs/docs/faq.mdx
+++ b/docs/docs/faq.mdx
@@ -38,3 +38,24 @@ function run2() {
   GmailProcessorLib.run(config2, ...)
 }
 ```
+
+## How do I store GDrive attachments in emails?
+
+Use the following config snippet to extract the fileId and filename of the GDrive attachment from the email body and use it for the download URL of the `message.storeFromURL` action:
+
+```json
+  {
+    "match": {
+      "body": "(?s)<a href=\"https://drive.google.com/file/d/(?<fileId>[^/]+)/view\\?usp=drivesdk\".*<span [^>]+>(?<filename>[^<]+)</span>"
+    },
+    "actions": [
+      {
+        "name": "message.storeFromURL",
+        "args": {
+          "url": "https://drive.google.com/uc?id=${message.body.match.fileId}&export=download",
+          "location": "/some-path/${message.body.match.filename}",
+        }
+      }
+    ]
+  }
+```

--- a/src/lib/config/MessageMatchConfig.ts
+++ b/src/lib/config/MessageMatchConfig.ts
@@ -9,7 +9,8 @@ import { MessageFlag } from "./MessageFlag"
  */
 export class MessageMatchConfig {
   /**
-   * A RegEx matching the body of messages
+   * A RegEx matching the body of messages.
+   * Use `(?s)` at the beginning of the regex if you want `.` to match a newline.
    */
   body? = ".*"
   /**
@@ -29,7 +30,8 @@ export class MessageMatchConfig {
    */
   olderThan? = ""
   /**
-   * A RegEx matching the plain body of messages
+   * A RegEx matching the plain body of messages.
+   * Use `(?s)` at the beginning of the regex if you want `.` to match a newline.
    */
   plainBody? = ".*"
   /**

--- a/src/lib/config/config-schema-v2.json
+++ b/src/lib/config/config-schema-v2.json
@@ -301,7 +301,7 @@
             "properties": {
                 "body": {
                     "default": ".*",
-                    "description": "A RegEx matching the body of messages",
+                    "description": "A RegEx matching the body of messages.\nUse `(?s)` at the beginning of the regex if you want `.` to match a newline.",
                     "title": "body",
                     "type": "string"
                 },
@@ -334,7 +334,7 @@
                 },
                 "plainBody": {
                     "default": ".*",
-                    "description": "A RegEx matching the plain body of messages",
+                    "description": "A RegEx matching the plain body of messages.\nUse `(?s)` at the beginning of the regex if you want `.` to match a newline.",
                     "title": "plainBody",
                     "type": "string"
                 },

--- a/src/lib/processors/AttachmentProcessor.spec.ts
+++ b/src/lib/processors/AttachmentProcessor.spec.ts
@@ -101,6 +101,27 @@ it("should match attachments with matching parameters", () => {
         },
         matched: [],
       },
+      {
+        // Matching name
+        config: {
+          name: "attachment-1.txt",
+        },
+        matched: ["attachment-1.txt"],
+      },
+      {
+        // Non-matching name (case-sensitive)
+        config: {
+          name: "ATTACHMENT-1.txt",
+        },
+        matched: [],
+      },
+      {
+        // Matching name (case-insensitive)
+        config: {
+          name: "(?i)ATTACHMENT-1.txt",
+        },
+        matched: ["attachment-1.txt"],
+      },
     ]
   const mockedMessage = GMailMocks.newMessageMock({
     attachments: [

--- a/src/lib/processors/AttachmentProcessor.ts
+++ b/src/lib/processors/AttachmentProcessor.ts
@@ -46,14 +46,16 @@ export class AttachmentProcessor extends BaseProcessor {
     attachment: GoogleAppsScript.Gmail.GmailAttachment,
   ) {
     try {
-      if (!RegExp(matchConfig.contentType).exec(attachment.getContentType()))
+      if (
+        !this.matchRegExp(matchConfig.contentType, attachment.getContentType())
+      )
         return this.noMatch(
           ctx,
           `contentType '${attachment.getContentType()}' does not match '${
             matchConfig.contentType
           }'`,
         )
-      if (!RegExp(matchConfig.name).exec(attachment.getName()))
+      if (!this.matchRegExp(matchConfig.name, attachment.getName()))
         return this.noMatch(
           ctx,
           `name '${attachment.getName()}' does not match '${matchConfig.name}'`,

--- a/src/lib/processors/BaseProcessor.ts
+++ b/src/lib/processors/BaseProcessor.ts
@@ -33,12 +33,11 @@ export abstract class BaseProcessor {
     let matchesAll = true
     regexMap.forEach((value, k) => {
       ctx.log.debug(`Testing regex match for ${k} ...`)
-      const regex = new RegExp(value, "g")
       let result
       const keyName = `${keyPrefix}.${k}`
       let hasAtLeastOneMatch = false
       const stringValue = PatternUtil.stringValue(ctx, keyName, m)
-      if ((result = regex.exec(stringValue)) !== null) {
+      if ((result = this.matchRegExp(value, stringValue)) !== null) {
         ctx.log.debug(`... matches`)
         hasAtLeastOneMatch = true
         for (let i = 1; i < result.length; i++) {
@@ -138,6 +137,16 @@ export abstract class BaseProcessor {
       return isNewer ? matchTime < compareTime : matchTime >= compareTime
     }
     return true
+  }
+
+  protected static matchRegExp(regex: string, str: string, flags = "") {
+    const inlineModifierRegExp = /^\(\?(?<flags>[gimsuy]+)\)/
+    const res = inlineModifierRegExp.exec(regex)
+    if (res) {
+      const len = res[0].length
+      regex = regex.slice(len)
+    }
+    return RegExp(regex, flags + (res?.groups?.flags ?? "")).exec(str)
   }
 
   protected static matchError(

--- a/src/lib/processors/MessageProcessor.spec.ts
+++ b/src/lib/processors/MessageProcessor.spec.ts
@@ -2,6 +2,7 @@ import { GMailMocks } from "../../test/mocks/GMailMocks"
 import { MockFactory, Mocks } from "../../test/mocks/MockFactory"
 import { newMessageConfig } from "../config/MessageConfig"
 import { MessageFlag } from "../config/MessageFlag"
+import { MessageMatchConfig } from "../config/MessageMatchConfig"
 import { MessageProcessor } from "./MessageProcessor"
 
 let mocks: Mocks
@@ -12,7 +13,7 @@ beforeEach(() => {
 
 describe("match()", () => {
   it("should match messages with matching parameters", () => {
-    const matchExamples = [
+    const matchExamples: { config: MessageMatchConfig; matched: string[] }[] = [
       {
         config: {
           from: "from[0-1]@example.com",
@@ -73,6 +74,18 @@ describe("match()", () => {
         },
         matched: ["message-2"],
       },
+      {
+        config: {
+          body: "Test.+message 1",
+        },
+        matched: [],
+      },
+      {
+        config: {
+          body: "(?s)Test.+message 1",
+        },
+        matched: ["message-1"],
+      },
     ]
     const mockedThread = GMailMocks.newThreadMock({
       messages: [
@@ -82,6 +95,7 @@ describe("match()", () => {
           to: "to1@example.com",
           isStarred: false,
           isUnread: true,
+          body: "Test\nmessage 1",
         },
         {
           from: "from2@example.com",
@@ -89,6 +103,7 @@ describe("match()", () => {
           to: "to2@example.com",
           isStarred: true,
           isUnread: false,
+          body: "Test\nmessage 2",
         },
       ],
     })

--- a/src/lib/processors/MessageProcessor.ts
+++ b/src/lib/processors/MessageProcessor.ts
@@ -49,31 +49,31 @@ export class MessageProcessor extends BaseProcessor {
     message: GoogleAppsScript.Gmail.GmailMessage,
   ) {
     try {
-      if (!RegExp(matchConfig.body).exec(message.getBody()))
+      if (!this.matchRegExp(matchConfig.body, message.getBody()))
         return this.noMatch(
           ctx,
-          `from '${message.getBody().slice(0, 32)}...' does not match '${
+          `body '${message.getBody().slice(0, 32)}...' does not match '${
             matchConfig.body
           }'`,
         )
-      if (!RegExp(matchConfig.from).exec(message.getFrom()))
+      if (!this.matchRegExp(matchConfig.from, message.getFrom()))
         return this.noMatch(
           ctx,
           `from '${message.getFrom()}' does not match '${matchConfig.from}'`,
         )
-      if (!RegExp(matchConfig.body).exec(message.getPlainBody()))
+      if (!this.matchRegExp(matchConfig.plainBody, message.getPlainBody()))
         return this.noMatch(
           ctx,
-          `from '${message.getPlainBody().slice(0, 32)}...' does not match '${
-            matchConfig.plainBody
-          }'`,
+          `plainBody '${message
+            .getPlainBody()
+            .slice(0, 32)}...' does not match '${matchConfig.plainBody}'`,
         )
-      if (!RegExp(matchConfig.to).exec(message.getTo()))
+      if (!this.matchRegExp(matchConfig.to, message.getTo()))
         return this.noMatch(
           ctx,
           `to '${message.getTo()}' does not match '${matchConfig.to}'`,
         )
-      if (!RegExp(matchConfig.subject).exec(message.getSubject() ?? ""))
+      if (!this.matchRegExp(matchConfig.subject, message.getSubject() ?? ""))
         return this.noMatch(
           ctx,
           `subject '${message.getSubject()}' does not match '${

--- a/src/lib/processors/ThreadProcessor.ts
+++ b/src/lib/processors/ThreadProcessor.ts
@@ -257,7 +257,8 @@ export class ThreadProcessor extends BaseProcessor {
   ): boolean {
     try {
       if (
-        !RegExp(matchConfig.firstMessageSubject).exec(
+        !this.matchRegExp(
+          matchConfig.firstMessageSubject,
           thread.getFirstMessageSubject() ?? "",
         )
       )


### PR DESCRIPTION
# Description

This PR adds support for regular expression modifier flags that can be placed within the regex configuration string using the following syntax: `(?<modifier>)...`
The syntax is similar to the one used by perl-compatible regular expressions, but are limited to the modifier flags supported by JavaScript passed as 2nd argument to `new RegExp(<regex>,<flags>)`. Note, that the modifier syntax can only be used at the very beginning of the regex.

Fixes #45, #51, #87

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How has this been tested?

- [x] Unit tests in `AttachmentProcessor.spec.ts` and `MessageProcessor.spec.ts`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
