### PR TITLE
thread.storePDF-->attachment.store correction in docs

### DIFF
--- a/src/gas/examples/example01.js
+++ b/src/gas/examples/example01.js
@@ -36,7 +36,7 @@ export const example01Config = {
       },
       actions: [
         {
-          name: "thread.storePDF",
+          name: "attachment.store",
           args: {
             location: "GmailProcessor-Tests/${thread.firstMessageSubject}.pdf",
             conflictStrategy: "keep",

--- a/src/gas/examples/example01.json
+++ b/src/gas/examples/example01.json
@@ -27,7 +27,7 @@
       },
       "actions": [
         {
-          "name": "thread.storePDF",
+          "name": "attachment.store",
           "args": {
             "location": "GmailProcessor-Tests/${thread.firstMessageSubject}.pdf",
             "conflictStrategy": "keep"

--- a/src/gas/examples/example02.js
+++ b/src/gas/examples/example02.js
@@ -52,7 +52,7 @@ export const example02Config = {
       },
       actions: [
         {
-          name: "thread.storePDF",
+          name: "attachment.store",
           args: {
             location: "GmailProcessor-Tests/${thread.firstMessageSubject}.pdf",
             conflictStrategy: "keep",

--- a/src/gas/examples/example02.json
+++ b/src/gas/examples/example02.json
@@ -43,7 +43,7 @@
       },
       "actions": [
         {
-          "name": "thread.storePDF",
+          "name": "attachment.store",
           "args": {
             "location": "GmailProcessor-Tests/${thread.firstMessageSubject}.pdf",
             "conflictStrategy": "keep"


### PR DESCRIPTION
# Description

Using this project for the first time, ran the example and everything worked - except the desired result was not achieved. Reviewing the documentation looks like it was just a case of using the wrong action.
documentation 
```json
{
      "description": "Store all attachments sent to my.name+scans@gmail.com to the folder 'Scans'",
...
      "actions": [
        {
          "name": "thread.storePDF",
...

```
The example would actually "Store the entire email thread  sent to my.name+scans@gmail.com to the folder 'Scans'"


**relevant documentation is correct**
<img width="906" alt="Screen Shot 2024-01-29 at 9 38 33 PM" src="https://github.com/ahochsteger/gmail-processor/assets/9630328/0db49f1a-6be9-423d-b2e6-1c77546f54c3">
<img width="885" alt="Screen Shot 2024-01-29 at 9 38 49 PM" src="https://github.com/ahochsteger/gmail-processor/assets/9630328/55823260-050b-4072-a97e-7732d7b6b1d2">


## Type of change

Please delete options that are not relevant.

- [ ] Other type of change (test, build, refactoring, ...)

update to documentation to correct the action to match the  description .


## How has this been tested?

I ran the example in my environment. and it produced a PDF of the email thread instead of placing the attachment into gdrive.
<img width="801" alt="Screen Shot 2024-01-29 at 10 02 26 PM" src="https://github.com/ahochsteger/gmail-processor/assets/9630328/20ca409d-f3bb-467a-a0a5-efbbd51620a0">


## Checklist

- [x ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ x] I have made corresponding changes to the documentation
- [x ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
