### PR TITLE
feat: add ordering of threads/messages/attachments

### DIFF
--- a/docs/docs/reference/enum-types.mdx
+++ b/docs/docs/reference/enum-types.mdx
@@ -6,6 +6,16 @@ sidebar_position: 32
 
 These are the supported enum types and the possible values that can be used in the configuration.
 
+## AttachmentOrderField
+
+Represents an attachment field to be ordered by for processing.
+
+| Value | Description |
+|-------|-------------|
+| `contentType` | Order by the content type of the attachment. |
+| `hash` | Order by the hash of the attachment. |
+| `name` | Order by the name of the attachment. |
+
 ## ConflictStrategy
 
 Strategy that defines how to deal in case of conflicts with already existing files at the desired location in Google Drive.
@@ -85,6 +95,17 @@ A flag to match messages with certain properties.
 | `unread` | Matches unread messages. |
 | `unstarred` | Matches un-starred messages. |
 
+## MessageOrderField
+
+Represents a message field to be ordered by for processing.
+
+| Value | Description |
+|-------|-------------|
+| `date` | Order by the date of the message. |
+| `from` | Order by the sender of the message. |
+| `id` | Order by the ID of the message. |
+| `subject` | Order by the subject of the message. |
+
 ## MetaInfoType
 
 The type of meta information used for context substitution placeholders.
@@ -96,6 +117,15 @@ The type of meta information used for context substitution placeholders.
 | `number` | A numeric data type. |
 | `string` | A string data type. |
 | `variable` | A custom configuration variable. |
+
+## OrderDirection
+
+Represents the direction a list should be ordered.
+
+| Value | Description |
+|-------|-------------|
+| `asc` | Order ascending. |
+| `desc` | Order descending. |
 
 ## PlaceholderModifierType
 
@@ -148,3 +178,13 @@ The runtime mode in which processing takes place.
 | `dangerous` | This run-mode will execute all configured actions including possibly destructive actions like overwriting files or removing threads or messages.<br />ATTENTION: Use this only if you know exactly what you're doing and won't complain if something goes wrong! |
 | `dry-run` | This run-mode skips execution of writing actions. Use this for testing config changes or library upgrades. |
 | `safe-mode` | This run-mode can be used for normal operation but will skip possibly destructive actions like overwriting files or removing threads or messages. |
+
+## ThreadOrderField
+
+Represents a thread field to be ordered by for processing.
+
+| Value | Description |
+|-------|-------------|
+| `lastMessageDate` | Order by the date of the last message in the thread. |
+| `id` | Order by the ID of the thread. |
+| `firstMessageSubject` | Order by the subject of the first message in the thread. |

--- a/src/lib/config/AttachmentConfig.ts
+++ b/src/lib/config/AttachmentConfig.ts
@@ -12,6 +12,25 @@ import {
   essentialAttachmentMatchConfig,
   newAttachmentMatchConfig,
 } from "./AttachmentMatchConfig"
+import { OrderDirection } from "./CommonConfig"
+
+/**
+ * Represents an attachment field to be ordered by for processing.
+ */
+export enum AttachmentOrderField {
+  /**
+   * Order by the content type of the attachment.
+   */
+  CONTENT_TYPE = "contentType",
+  /**
+   * Order by the hash of the attachment.
+   */
+  HASH = "hash",
+  /**
+   * Order by the name of the attachment.
+   */
+  NAME = "name",
+}
 
 /**
  * Represents a config to handle a certain GMail attachment
@@ -39,6 +58,16 @@ export class AttachmentConfig {
    */
   @Expose()
   name? = ""
+  /**
+   * The field to order attachments by for processing.
+   */
+  @Expose()
+  orderBy?: AttachmentOrderField = undefined
+  /**
+   * The direction to order attachments for processing.
+   */
+  @Expose()
+  orderDirection?: OrderDirection = undefined
 }
 
 export type RequiredAttachmentConfig = RequiredDeep<AttachmentConfig>

--- a/src/lib/config/CommonConfig.ts
+++ b/src/lib/config/CommonConfig.ts
@@ -1,0 +1,18 @@
+/**
+ * Represents the direction a list should be ordered.
+ */
+export enum OrderDirection {
+  /**
+   * Order ascending.
+   */
+  ASC = "asc",
+  /**
+   * Order descending.
+   */
+  DESC = "desc",
+}
+
+export type OrderableEntityConfig<T extends string> = {
+  orderBy: T
+  orderDirection: OrderDirection
+}

--- a/src/lib/config/MessageConfig.ts
+++ b/src/lib/config/MessageConfig.ts
@@ -12,11 +12,34 @@ import {
   essentialAttachmentConfig,
   normalizeAttachmentConfigs,
 } from "./AttachmentConfig"
+import { OrderDirection } from "./CommonConfig"
 import {
   MessageMatchConfig,
   essentialMessageMatchConfig,
   newMessageMatchConfig,
 } from "./MessageMatchConfig"
+
+/**
+ * Represents a message field to be ordered by for processing.
+ */
+export enum MessageOrderField {
+  /**
+   * Order by the date of the message.
+   */
+  DATE = "date",
+  /**
+   * Order by the sender of the message.
+   */
+  FROM = "from",
+  /**
+   * Order by the ID of the message.
+   */
+  ID = "id",
+  /**
+   * Order by the subject of the message.
+   */
+  SUBJECT = "subject",
+}
 
 /**
  * Represents a config to handle a certain GMail message
@@ -50,6 +73,16 @@ export class MessageConfig {
    */
   @Expose()
   name? = ""
+  /**
+   * The field to order messages by for processing.
+   */
+  @Expose()
+  orderBy?: MessageOrderField = undefined
+  /**
+   * The direction to order messages for processing.
+   */
+  @Expose()
+  orderDirection?: OrderDirection = undefined
 }
 
 export type RequiredMessageConfig = RequiredDeep<MessageConfig>

--- a/src/lib/config/ThreadConfig.ts
+++ b/src/lib/config/ThreadConfig.ts
@@ -8,6 +8,7 @@ import {
   essentialThreadActionConfig,
 } from "./ActionConfig"
 import { AttachmentConfig, essentialAttachmentConfig } from "./AttachmentConfig"
+import { OrderDirection } from "./CommonConfig"
 import {
   MessageConfig,
   essentialMessageConfig,
@@ -18,6 +19,24 @@ import {
   essentialThreadMatchConfig,
   newThreadMatchConfig,
 } from "./ThreadMatchConfig"
+
+/**
+ * Represents a thread field to be ordered by for processing.
+ */
+export enum ThreadOrderField {
+  /**
+   * Order by the date of the last message in the thread.
+   */
+  DATE = "lastMessageDate",
+  /**
+   * Order by the ID of the thread.
+   */
+  ID = "id",
+  /**
+   * Order by the subject of the first message in the thread.
+   */
+  SUBJECT = "firstMessageSubject",
+}
 
 /**
  * Represents a config handle a certain GMail thread
@@ -57,6 +76,16 @@ export class ThreadConfig {
    */
   @Expose()
   name? = ""
+  /**
+   * The field to order threads by for processing.
+   */
+  @Expose()
+  orderBy?: ThreadOrderField = undefined
+  /**
+   * The direction to order threads for processing.
+   */
+  @Expose()
+  orderDirection?: OrderDirection = undefined
 }
 
 export type RequiredThreadConfig = RequiredDeep<ThreadConfig>

--- a/src/lib/config/config-schema-v2.json
+++ b/src/lib/config/config-schema-v2.json
@@ -31,6 +31,25 @@
                     "description": "The unique name of the attachment config (will be generated if not set)",
                     "title": "name",
                     "type": "string"
+                },
+                "orderBy": {
+                    "description": "The field to order attachments by for processing.",
+                    "enum": [
+                        "contentType",
+                        "hash",
+                        "name"
+                    ],
+                    "title": "orderBy",
+                    "type": "string"
+                },
+                "orderDirection": {
+                    "description": "The direction to order attachments for processing.",
+                    "enum": [
+                        "asc",
+                        "desc"
+                    ],
+                    "title": "orderDirection",
+                    "type": "string"
                 }
             },
             "title": "AttachmentConfig",
@@ -1548,6 +1567,26 @@
                     "description": "The unique name of the message config (will be generated if not set)",
                     "title": "name",
                     "type": "string"
+                },
+                "orderBy": {
+                    "description": "The field to order messages by for processing.",
+                    "enum": [
+                        "date",
+                        "from",
+                        "id",
+                        "subject"
+                    ],
+                    "title": "orderBy",
+                    "type": "string"
+                },
+                "orderDirection": {
+                    "description": "The direction to order messages for processing.",
+                    "enum": [
+                        "asc",
+                        "desc"
+                    ],
+                    "title": "orderDirection",
+                    "type": "string"
                 }
             },
             "title": "MessageConfig",
@@ -3045,6 +3084,25 @@
                     "default": "",
                     "description": "The unique name of the thread config (will be generated if not set)",
                     "title": "name",
+                    "type": "string"
+                },
+                "orderBy": {
+                    "description": "The field to order threads by for processing.",
+                    "enum": [
+                        "firstMessageSubject",
+                        "id",
+                        "lastMessageDate"
+                    ],
+                    "title": "orderBy",
+                    "type": "string"
+                },
+                "orderDirection": {
+                    "description": "The direction to order threads for processing.",
+                    "enum": [
+                        "asc",
+                        "desc"
+                    ],
+                    "title": "orderDirection",
                     "type": "string"
                 }
             },

--- a/src/lib/processors/AttachmentProcessor.spec.ts
+++ b/src/lib/processors/AttachmentProcessor.spec.ts
@@ -1,12 +1,16 @@
 import { GMailMocks } from "../../test/mocks/GMailMocks"
 import { MockFactory, Mocks } from "../../test/mocks/MockFactory"
 import { ProcessingStatus } from "../Context"
-import { newAttachmentConfig } from "../config/AttachmentConfig"
+import {
+  AttachmentOrderField,
+  newAttachmentConfig,
+} from "../config/AttachmentConfig"
 import {
   AttachmentMatchConfig,
   RequiredAttachmentMatchConfig,
   newAttachmentMatchConfig,
 } from "../config/AttachmentMatchConfig"
+import { OrderDirection } from "../config/CommonConfig"
 import { AttachmentProcessor } from "./AttachmentProcessor"
 
 let mocks: Mocks
@@ -185,5 +189,44 @@ it("should process an attachment entity", () => {
   const result = AttachmentProcessor.processEntity(mocks.attachmentContext)
   expect(result).toMatchObject({
     status: ProcessingStatus.OK,
+  })
+})
+
+describe("order attachments", () => {
+  let attachments = [
+    GMailMocks.newAttachmentMock({
+      hash: "a1",
+      name: "2",
+    }),
+    GMailMocks.newAttachmentMock({
+      hash: "a2",
+      name: "1",
+    }),
+    GMailMocks.newAttachmentMock({
+      hash: "a3",
+      name: "3",
+    }),
+  ]
+  it("should order threads ascending", () => {
+    attachments = AttachmentProcessor.ordered(
+      attachments,
+      {
+        orderBy: AttachmentOrderField.NAME,
+        orderDirection: OrderDirection.ASC,
+      },
+      AttachmentProcessor.orderRules,
+    )
+    expect(attachments.map((t) => t.getHash())).toEqual(["a2", "a1", "a3"])
+  })
+  it("should order threads ascending", () => {
+    attachments = AttachmentProcessor.ordered(
+      attachments,
+      {
+        orderBy: AttachmentOrderField.NAME,
+        orderDirection: OrderDirection.DESC,
+      },
+      AttachmentProcessor.orderRules,
+    )
+    expect(attachments.map((t) => t.getHash())).toEqual(["a3", "a1", "a2"])
   })
 })

--- a/src/lib/processors/BaseProcessor.ts
+++ b/src/lib/processors/BaseProcessor.ts
@@ -20,6 +20,7 @@ import {
 import { ActionArgsType, ActionReturnType } from "../actions/ActionRegistry"
 import { ActionConfig, ProcessingStage } from "../config/ActionConfig"
 import { AttachmentMatchConfig } from "../config/AttachmentMatchConfig"
+import { OrderableEntityConfig } from "../config/CommonConfig"
 import { MessageMatchConfig } from "../config/MessageMatchConfig"
 import { ThreadMatchConfig } from "../config/ThreadMatchConfig"
 import { PatternUtil } from "../utils/PatternUtil"
@@ -441,32 +442,14 @@ export abstract class BaseProcessor {
     return `${description}See [${title}](https://developers.google.com/apps-script/reference/gmail/gmail-${type}#${method}\\(\\)) reference docs.`
   }
 
-  protected static getConfigName(
-    // TODO: Remove, is obsolete now.
-    ctx: ThreadContext | MessageContext | AttachmentContext,
-    namePrefix = "",
-  ) {
-    let threadName = ""
-    let messageName = ""
-    let attachmentName = ""
-    if ((ctx as ThreadContext).thread) {
-      const threadCtx = ctx as ThreadContext
-      threadName =
-        threadCtx.thread.config.name ??
-        `${threadCtx.thread.config.name}-${threadCtx.thread.configIndex}`
+  public static ordered<T, C extends string>(
+    entities: T[],
+    config: OrderableEntityConfig<C>,
+    orderRulesFn: (a: T, b: T, config: OrderableEntityConfig<C>) => number,
+  ): T[] {
+    if (config.orderBy && config.orderDirection) {
+      entities = entities.sort((a: T, b: T) => orderRulesFn(a, b, config))
     }
-    if ((ctx as MessageContext).message) {
-      const messageCtx = ctx as MessageContext
-      messageName =
-        messageCtx.message.config.name ??
-        `-${messageCtx.message.config.name}-${messageCtx.message.configIndex}`
-    }
-    if ((ctx as AttachmentContext).message) {
-      const attachmentCtx = ctx as AttachmentContext
-      attachmentName =
-        attachmentCtx.attachment.config.name ??
-        `-${attachmentCtx.attachment.config.name}-${attachmentCtx.attachment.configIndex}`
-    }
-    return `${namePrefix}${threadName}${messageName}${attachmentName}`
+    return entities
   }
 }

--- a/src/lib/processors/MessageProcessor.spec.ts
+++ b/src/lib/processors/MessageProcessor.spec.ts
@@ -1,6 +1,7 @@
 import { GMailMocks } from "../../test/mocks/GMailMocks"
 import { MockFactory, Mocks } from "../../test/mocks/MockFactory"
-import { newMessageConfig } from "../config/MessageConfig"
+import { OrderDirection } from "../config/CommonConfig"
+import { MessageOrderField, newMessageConfig } from "../config/MessageConfig"
 import { MessageFlag } from "../config/MessageFlag"
 import { MessageMatchConfig } from "../config/MessageMatchConfig"
 import { MessageProcessor } from "./MessageProcessor"
@@ -129,5 +130,38 @@ describe("processEntity()", () => {
   it("should process a message config", () => {
     const ctx = mocks.messageContext
     MessageProcessor.processEntity(ctx)
+  })
+})
+
+describe("order messages", () => {
+  let messages = [
+    GMailMocks.newMessageMock({
+      id: "m1",
+      date: new Date(2024, 5, 10),
+    }),
+    GMailMocks.newMessageMock({
+      id: "m2",
+      date: new Date(2024, 5, 9),
+    }),
+    GMailMocks.newMessageMock({
+      id: "m3",
+      date: new Date(2024, 5, 11),
+    }),
+  ]
+  it("should order threads ascending", () => {
+    messages = MessageProcessor.ordered(
+      messages,
+      { orderBy: MessageOrderField.DATE, orderDirection: OrderDirection.ASC },
+      MessageProcessor.orderRules,
+    )
+    expect(messages.map((t) => t.getId())).toEqual(["m2", "m1", "m3"])
+  })
+  it("should order threads ascending", () => {
+    messages = MessageProcessor.ordered(
+      messages,
+      { orderBy: MessageOrderField.DATE, orderDirection: OrderDirection.DESC },
+      MessageProcessor.orderRules,
+    )
+    expect(messages.map((t) => t.getId())).toEqual(["m3", "m1", "m2"])
   })
 })

--- a/src/test/mocks/GMailMocks.ts
+++ b/src/test/mocks/GMailMocks.ts
@@ -225,12 +225,14 @@ export class GMailMocks {
       isInTrash: data.isInTrash ?? false,
       isUnread: data.isUnread ?? true,
       labels: data.labels ?? [],
-      lastMessageDate: messages.reduce((lastMessage, currentMessage) =>
-        lastMessage.date.getMilliseconds() <
-        currentMessage.date.getMilliseconds()
-          ? currentMessage
-          : lastMessage,
-      ).date,
+      lastMessageDate:
+        data.lastMessageDate ??
+        messages.reduce((lastMessage, currentMessage) =>
+          lastMessage.date.getMilliseconds() <
+          currentMessage.date.getMilliseconds()
+            ? currentMessage
+            : lastMessage,
+        ).date,
       messageCount: messages.length,
       messages: messages,
       permalink: data.permalink ?? "some-permalink-url",
@@ -296,9 +298,11 @@ export class GMailMocks {
     const sampleContent = data.content ?? "Sample text content"
     const sampleData: RequiredAttachmentData = {
       contentType: data.contentType ?? "text/plain",
-      hash: crypto.createHash("sha1").update(sampleContent).digest("hex"),
+      hash:
+        data.hash ??
+        crypto.createHash("sha1").update(sampleContent).digest("hex"),
       name: data.name ?? "attachment.txt",
-      size: this.lengthInUtf8Bytes(sampleContent),
+      size: data.size ?? this.lengthInUtf8Bytes(sampleContent),
       isGoogleType: data.isGoogleType ?? false,
       content: sampleContent,
     }


### PR DESCRIPTION
# Description

This PR adds the possibility to control the processing order of threads, messages and attachments.

Fixes #346

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How has this been tested?

Please describe the test configurations that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. If possible, create an example that can be used as documentation and automated test run.

- [x] [AttachmentProcessor.spec.ts](https://github.com/ahochsteger/gmail-processor/blob/fef236ebff9409ae2349db902b5a9f28794f58b6/src/lib/processors/AttachmentProcessor.spec.ts#L195)
- [x] [MessageProcessor.spec.ts](https://github.com/ahochsteger/gmail-processor/blob/fef236ebff9409ae2349db902b5a9f28794f58b6/src/lib/processors/MessageProcessor.spec.ts#L136)
- [x] [ThreadProcessor.spec.ts](https://github.com/ahochsteger/gmail-processor/blob/fef236ebff9409ae2349db902b5a9f28794f58b6/src/lib/processors/ThreadProcessor.spec.ts#L114)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
