### PR TITLE
fix: null dereference in redact()

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -77,7 +77,7 @@ jobs:
       - id: release-status
         if: ${{ !github.event.inputs.skip_release }}
         name: Release Status
-        uses: cycjimmy/semantic-release-action@v3
+        uses: cycjimmy/semantic-release-action@cb425203a562475bca039ba4dbf90c7f9ac790f4 # v4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -89,7 +89,7 @@ jobs:
       - id: sonarcloud
         if: ${{ !github.event.inputs.skip_sonarcloud }}
         name: SonarCloud Scan
-        uses: sonarsource/sonarcloud-github-action@master
+        uses: sonarsource/sonarcloud-github-action@49e6cd3b187936a73b8280d59ffd9da69df63ec9 # v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
@@ -103,7 +103,7 @@ jobs:
       - id: release
         if: ${{ !github.event.inputs.skip_release }}
         name: Release
-        uses: cycjimmy/semantic-release-action@v3
+        uses: cycjimmy/semantic-release-action@cb425203a562475bca039ba4dbf90c7f9ac790f4 # v4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - id: deploy-lib

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -57,7 +57,7 @@ jobs:
       - id: sonarcloud
         if: ${{ env.SONAR_TOKEN && !github.event.inputs.skip_sonarcloud }}
         name: SonarCloud Scan
-        uses: sonarsource/sonarcloud-github-action@master
+        uses: sonarsource/sonarcloud-github-action@49e6cd3b187936a73b8280d59ffd9da69df63ec9 # v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -21,6 +21,7 @@ export default {
 
   // An array of glob patterns indicating a set of files for which coverage information should be collected
   // collectCoverageFrom: undefined,
+  collectCoverageFrom: ["src/lib/**/*.ts"],
 
   // The directory where Jest should output its coverage files
   coverageDirectory: "build/coverage",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "ci": "npm run ci:build && npm run ci:test && npm run ci:docs",
     "ci:build": "npm run clean && npm ci && npm run build && npm run lint:code",
     "ci:docs": "npm run clean:docs && npm ci && ( cd docs && npm ci ) && npm run build:docs",
-    "ci:test": "jest --ci --coverage",
+    "ci:test": "TZ=UTC jest --ci --coverage",
     "clean": "rm -rf build docs/build",
     "clean:docs": "rm -rf docs/build",
     "clean:examples": "scripts/clasp.sh examples clean",

--- a/src/lib/utils/Logger.spec.ts
+++ b/src/lib/utils/Logger.spec.ts
@@ -16,94 +16,104 @@ afterEach(() => {
   spy?.mockReset()
 })
 
-it("should log a trace message", () => {
-  spy = jest.spyOn(console, "log").mockImplementation()
-  spy.mockClear()
-  logger.trace(mocks.processingContext, {
-    location: "Logger.spec",
-    message: "Log message",
+describe("log levels", () => {
+  it("should log a trace message", () => {
+    spy = jest.spyOn(console, "log").mockImplementation()
+    spy.mockClear()
+    logger.trace(mocks.processingContext, {
+      location: "Logger.spec",
+      message: "Log message",
+    })
+    expect(spy.mock.calls?.[0]?.[0]).toMatch(
+      /^[^ ]+ TRACE \[Logger\.spec\] Log message$/,
+    )
   })
-  expect(spy.mock.calls?.[0]?.[0]).toMatch(
-    /^[^ ]+ TRACE \[Logger\.spec\] Log message$/,
-  )
+
+  it("should log a debug message", () => {
+    spy = jest.spyOn(console, "log").mockImplementation()
+    spy.mockClear()
+    logger.debug("Log message")
+    expect(spy.mock.calls[0][0]).toMatch(/^[^ ]+ DEBUG Log message$/)
+  })
+
+  it("should log an info message", () => {
+    spy = jest.spyOn(console, "log").mockImplementation()
+    spy.mockClear()
+    logger.info("Log message")
+    expect(spy.mock.calls[0][0]).toMatch(/^[^ ]+ INFO Log message$/)
+  })
+
+  it("should log a warning message", () => {
+    const spy = jest.spyOn(console, "error").mockImplementation()
+    spy.mockClear()
+    logger.warn("Log message")
+    expect(spy.mock.calls[0][0]).toMatch(/^[^ ]+ WARN Log message$/)
+  })
+
+  it("should log an error message", () => {
+    const spy = jest.spyOn(console, "error").mockImplementation()
+    spy.mockClear()
+    logger.error("Log message")
+    expect(spy.mock.calls[0][0]).toMatch(/^[^ ]+ ERROR Log message$/)
+  })
+
+  it("should filter log levels", () => {
+    logger = new Logger(LogLevel.WARN)
+    const spyLog = jest.spyOn(console, "log")
+    const spyError = jest.spyOn(console, "error")
+    spyLog.mockClear()
+    logger.debug("Log message")
+    expect(spyLog).not.toHaveBeenCalled()
+    spyLog.mockClear()
+    logger.info("Log message")
+    expect(spyLog).not.toHaveBeenCalled()
+    spyError.mockClear()
+    logger.warn("Log message")
+    expect(spyError).toHaveBeenCalled()
+    spyError.mockClear()
+    logger.error("Log message")
+    expect(spyError).toHaveBeenCalled()
+  })
 })
 
-it("should log a debug message", () => {
-  spy = jest.spyOn(console, "log").mockImplementation()
-  spy.mockClear()
-  logger.debug("Log message")
-  expect(spy.mock.calls[0][0]).toMatch(/^[^ ]+ DEBUG Log message$/)
-})
+describe("logsheet", () => {
+  it("should trace to console and not logsheet", () => {
+    const config = ConfigMocks.newDefaultConfig()
+    config.settings.logSheetTracing = false
+    mocks = MockFactory.newMocks(config)
+    const ctx = mocks.processingContext
+    const logSpy = jest.spyOn(console, "log")
+    const sheetSpy = jest.spyOn(ctx.proc.spreadsheetAdapter, "log")
+    logSpy.mockClear()
+    sheetSpy.mockClear()
+    logger.trace(ctx, {
+      location: "Logger.logTrace()",
+      message: "Trace message",
+    })
+    expect(logSpy.mock.calls[0][0]).toMatch(
+      /^[^ ]+ TRACE \[Logger\.logTrace\(\)\] Trace message/,
+    )
+    expect(sheetSpy).not.toHaveBeenCalled()
+  })
 
-it("should log an info message", () => {
-  spy = jest.spyOn(console, "log").mockImplementation()
-  spy.mockClear()
-  logger.info("Log message")
-  expect(spy.mock.calls[0][0]).toMatch(/^[^ ]+ INFO Log message$/)
-})
-
-it("should log a warning message", () => {
-  const spy = jest.spyOn(console, "error").mockImplementation()
-  spy.mockClear()
-  logger.warn("Log message")
-  expect(spy.mock.calls[0][0]).toMatch(/^[^ ]+ WARN Log message$/)
-})
-
-it("should log an error message", () => {
-  const spy = jest.spyOn(console, "error").mockImplementation()
-  spy.mockClear()
-  logger.error("Log message")
-  expect(spy.mock.calls[0][0]).toMatch(/^[^ ]+ ERROR Log message$/)
-})
-
-it("should filter log levels", () => {
-  logger = new Logger(LogLevel.WARN)
-  const spyLog = jest.spyOn(console, "log")
-  const spyError = jest.spyOn(console, "error")
-  spyLog.mockClear()
-  logger.debug("Log message")
-  expect(spyLog).not.toHaveBeenCalled()
-  spyLog.mockClear()
-  logger.info("Log message")
-  expect(spyLog).not.toHaveBeenCalled()
-  spyError.mockClear()
-  logger.warn("Log message")
-  expect(spyError).toHaveBeenCalled()
-  spyError.mockClear()
-  logger.error("Log message")
-  expect(spyError).toHaveBeenCalled()
-})
-
-it("should trace to console and not logsheet", () => {
-  const config = ConfigMocks.newDefaultConfig()
-  config.settings.logSheetTracing = false
-  mocks = MockFactory.newMocks(config)
-  const ctx = mocks.processingContext
-  const logSpy = jest.spyOn(console, "log")
-  const sheetSpy = jest.spyOn(ctx.proc.spreadsheetAdapter, "log")
-  logSpy.mockClear()
-  sheetSpy.mockClear()
-  logger.trace(ctx, { location: "Logger.logTrace()", message: "Trace message" })
-  expect(logSpy.mock.calls[0][0]).toMatch(
-    /^[^ ]+ TRACE \[Logger\.logTrace\(\)\] Trace message/,
-  )
-  expect(sheetSpy).not.toHaveBeenCalled()
-})
-
-it("should trace to console and logsheet", () => {
-  const config = ConfigMocks.newDefaultConfig()
-  config.settings.logSheetTracing = true
-  mocks = MockFactory.newMocks(config)
-  const ctx = mocks.processingContext
-  const logSpy = jest.spyOn(console, "log")
-  const sheetSpy = jest.spyOn(ctx.proc.spreadsheetAdapter, "log")
-  logSpy.mockClear()
-  sheetSpy.mockClear()
-  logger.trace(ctx, { location: "Logger.logTrace()", message: "Trace message" })
-  expect(logSpy.mock.calls[0][0]).toMatch(
-    /^[^ ]+ TRACE \[Logger\.logTrace\(\)\] Trace message/,
-  )
-  expect(sheetSpy).toHaveBeenCalled()
+  it("should trace to console and logsheet", () => {
+    const config = ConfigMocks.newDefaultConfig()
+    config.settings.logSheetTracing = true
+    mocks = MockFactory.newMocks(config)
+    const ctx = mocks.processingContext
+    const logSpy = jest.spyOn(console, "log")
+    const sheetSpy = jest.spyOn(ctx.proc.spreadsheetAdapter, "log")
+    logSpy.mockClear()
+    sheetSpy.mockClear()
+    logger.trace(ctx, {
+      location: "Logger.logTrace()",
+      message: "Trace message",
+    })
+    expect(logSpy.mock.calls[0][0]).toMatch(
+      /^[^ ]+ TRACE \[Logger\.logTrace\(\)\] Trace message/,
+    )
+    expect(sheetSpy).toHaveBeenCalled()
+  })
 })
 
 describe("redact", () => {

--- a/src/lib/utils/Logger.spec.ts
+++ b/src/lib/utils/Logger.spec.ts
@@ -136,8 +136,12 @@ describe("redact", () => {
     const actual = logger.redact(mocks.processingContext, "abcdef")
     expect(actual).toEqual("abcdef")
   })
-  it("should gracefully handle null and undefined values", () => {
+  it("should gracefully handle null values", () => {
     const actual = logger.redact(mocks.processingContext, null)
+    expect(actual).toEqual("")
+  })
+  it("should gracefully handle undefined values", () => {
+    const actual = logger.redact(mocks.processingContext)
     expect(actual).toEqual("")
   })
 })

--- a/src/lib/utils/Logger.spec.ts
+++ b/src/lib/utils/Logger.spec.ts
@@ -103,3 +103,21 @@ it("should trace to console and logsheet", () => {
   )
   expect(sheetSpy).toHaveBeenCalled()
 })
+
+describe("redact", () => {
+  it("should show beginning and end of longer sensible information", () => {
+    const actual = logger.redact(
+      mocks.processingContext,
+      "abcdefghijklmnopqrstuvwxyz",
+    )
+    expect(actual).toEqual("abc...xyz")
+  })
+  it("should show (redacted) for shorter sensible information", () => {
+    const actual = logger.redact(mocks.processingContext, "abcdef")
+    expect(actual).toEqual("(redacted)")
+  })
+  it("should gracefully handle null and undefined values", () => {
+    const actual = logger.redact(mocks.processingContext, null)
+    expect(actual).toEqual("")
+  })
+})

--- a/src/lib/utils/Logger.ts
+++ b/src/lib/utils/Logger.ts
@@ -64,7 +64,10 @@ export class Logger {
       ctx.proc.spreadsheetAdapter.log(ctx, args)
     }
   }
-  redact(ctx: ProcessingContext, value: string): string {
+  redact(ctx: ProcessingContext, value?: string | null): string {
+    if (value === null || value === undefined) {
+      return ""
+    }
     switch (ctx.proc.config.settings.logSensitiveRedactionMode) {
       case LogRedactionMode.ALL:
         value = "(redacted)"

--- a/src/lib/utils/Logger.ts
+++ b/src/lib/utils/Logger.ts
@@ -65,9 +65,7 @@ export class Logger {
     }
   }
   redact(ctx: ProcessingContext, value?: string | null): string {
-    if (value === null || value === undefined) {
-      return ""
-    }
+    if (!value) return ""
     switch (ctx.proc.config.settings.logSensitiveRedactionMode) {
       case LogRedactionMode.ALL:
         value = "(redacted)"


### PR DESCRIPTION
# Description

Fixes a null dereference error in Logger.redact() and adds some tests for it.

Fixes #353 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

- [x] Unit tests in Logger.spec.ts

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
