### PR TITLE
wip: add decrypt pdf action

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "2.12.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "@cantoo/pdf-lib": "^2.2.0",
         "addressparser": "^1.0.1",
         "ajv": "8.16.0",
         "class-transformer": "^0.5.1",
@@ -728,6 +729,19 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@cantoo/pdf-lib": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@cantoo/pdf-lib/-/pdf-lib-2.2.0.tgz",
+      "integrity": "sha512-hR4UfkHNPazsHfyeNz0n06k69e4DIImwxsdF+GpNInFTQ1CDJbPk48u+efkX8P+znLN4eqZUJa1XlNBdGtS45g==",
+      "dependencies": {
+        "@pdf-lib/standard-fonts": "^1.0.0",
+        "@pdf-lib/upng": "^1.0.1",
+        "color": "^4.2.3",
+        "crypto-js": "^4.2.0",
+        "node-html-better-parser": "^1.4.0",
+        "pako": "^1.0.11"
+      }
     },
     "node_modules/@casualbot/jest-sonar-reporter": {
       "version": "2.3.1",
@@ -2477,6 +2491,22 @@
       "license": "MIT",
       "dependencies": {
         "@octokit/openapi-types": "^22.2.0"
+      }
+    },
+    "node_modules/@pdf-lib/standard-fonts": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@pdf-lib/standard-fonts/-/standard-fonts-1.0.0.tgz",
+      "integrity": "sha512-hU30BK9IUN/su0Mn9VdlVKsWBS6GyhVfqjwl1FjZN4TxP6cCw0jP2w7V3Hf5uX7M0AZJ16vey9yE0ny7Sa59ZA==",
+      "dependencies": {
+        "pako": "^1.0.6"
+      }
+    },
+    "node_modules/@pdf-lib/upng": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@pdf-lib/upng/-/upng-1.0.1.tgz",
+      "integrity": "sha512-dQK2FUMQtowVP00mtIksrlZhdFXQZPC+taih1q4CvPZ5vqdxR/LKBaFg0oAfzd1GlHZXXSPdQfzQnt+ViGvEIQ==",
+      "dependencies": {
+        "pako": "^1.0.10"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -6034,6 +6064,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/color": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+      "dependencies": {
+        "color-convert": "^2.0.1",
+        "color-string": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=12.5.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -6048,8 +6090,32 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
+    },
+    "node_modules/color/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "node_modules/colors": {
       "version": "1.4.0",
@@ -9412,6 +9478,21 @@
       "engines": {
         "node": ">=14"
       }
+    },
+    "node_modules/html-entities": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.5.2.tgz",
+      "integrity": "sha512-K//PSRMQk4FZ78Kyau+mZurHn3FH0Vwr+H36eE0rPbeYkRRi9YxceYPhuN60UwWorxyKHhqoAJl2OFKa4BVtaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/mdevils"
+        },
+        {
+          "type": "patreon",
+          "url": "https://patreon.com/mdevils"
+        }
+      ]
     },
     "node_modules/html-escaper": {
       "version": "2.0.2",
@@ -14029,6 +14110,14 @@
         "node": ">= 6.13.0"
       }
     },
+    "node_modules/node-html-better-parser": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/node-html-better-parser/-/node-html-better-parser-1.4.4.tgz",
+      "integrity": "sha512-uvlqL1uMU7m/aIY9WsGM0jDW7gVFIuFSWS6f2rlJeL7K1ZzKnA3B8cNbUGw9ywwYm9W7W2ooi0iQ7aI29aQmPw==",
+      "dependencies": {
+        "html-entities": "^2.3.2"
+      }
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -17181,6 +17270,11 @@
       "dev": true,
       "license": "BlueOak-1.0.0"
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -19710,6 +19804,19 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/simple-swizzle": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
+      }
+    },
+    "node_modules/simple-swizzle/node_modules/is-arrayish": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
     },
     "node_modules/sisteransi": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -136,6 +136,7 @@
   },
   "private": true,
   "dependencies": {
+    "@cantoo/pdf-lib": "^2.2.0",
     "addressparser": "^1.0.1",
     "ajv": "8.16.0",
     "class-transformer": "^0.5.1",

--- a/src/lib/actions/AttachmentActions.ts
+++ b/src/lib/actions/AttachmentActions.ts
@@ -2,6 +2,7 @@ import {
   ActionBaseConfig,
   AttachmentExtractTextArgs,
   StoreActionBaseArgs,
+  StoreAndDecryptActionBaseArgs,
 } from "../config/ActionConfig"
 import {
   AttachmentContext,
@@ -17,6 +18,7 @@ import {
   ActionProvider,
   ActionReturnType,
 } from "./ActionRegistry"
+import { getDecryptedPdf } from "lib/utils/PdfLibUtils"
 
 export class AttachmentActions implements ActionProvider<AttachmentContext> {
   [key: string]: ActionFunction<AttachmentContext>
@@ -107,6 +109,45 @@ export class AttachmentActions implements ActionProvider<AttachmentContext> {
       "attachment",
       "attachment",
       "attachment.store",
+    )
+    return {
+      ok: true,
+      file,
+      actionMeta,
+    }
+  }
+
+  /** Store and decrypt an attachment to a Google Drive location. */
+  @writingAction<AttachmentContext>()
+  public static storeAndDecrypt(
+    context: AttachmentContext,
+    args: StoreAndDecryptActionBaseArgs,
+  ): ActionReturnType & { file?: GoogleAppsScript.Drive.File } {
+    const location = PatternUtil.substitute(context, args.location)
+    const file = context.proc.gdriveAdapter.storeAttachment(
+      context.attachment.object,
+      {
+        ...args,
+        location: location,
+        description: PatternUtil.substitute(context, args.description ?? ""),
+      },
+    )
+    getDecryptedPdf(context.attachment.object, args.password).then((decryptedFile) => {
+      context.proc.gdriveAdapter.storeAttachment(
+        decryptedFile,
+        {
+          ...args,
+          location: PatternUtil.substitute(context, args.decryptedPdfLocation),
+          description: PatternUtil.substitute(context, args.decryptedPdfDescription ?? ""),
+        },
+      )
+    });
+    const actionMeta = context.proc.gdriveAdapter.getActionMeta(
+      file,
+      location,
+      "attachment",
+      "attachment",
+      "attachment.storeAndDecrypt",
     )
     return {
       ok: true,

--- a/src/lib/config/ActionConfig.ts
+++ b/src/lib/config/ActionConfig.ts
@@ -80,6 +80,24 @@ export type StoreActionBaseArgs = {
   toMimeType?: string
 }
 
+export type StoreAndDecryptActionBaseArgs = StoreActionBaseArgs & {
+  /**
+   * The password to be used for password-protected PDFs.
+   */
+  password: string
+  /**
+   * The location (path + filename) of the decrypted Google Drive file.
+   * For shared folders or Team Drives prepend the location with the folder ID like `{id:<folderId>}/...`.
+   * Supports placeholder substitution.
+   */
+  decryptedPdfLocation: string
+  /**
+   * The description to be attached to the decrypted Google Drive file.
+   * Supports placeholder substitution.
+   */
+  decryptedPdfDescription?: string
+}
+
 export type AttachmentExtractTextArgs = {
   /**
    * Hints at the language to use for OCR. Valid values are BCP 47 codes.

--- a/src/lib/utils/PdfLibUtils.ts
+++ b/src/lib/utils/PdfLibUtils.ts
@@ -1,0 +1,10 @@
+import { PDFDocument } from "@cantoo/pdf-lib"
+
+export async function getDecryptedPdf(processedFileObject: GoogleAppsScript.Gmail.GmailAttachment, password: string) {
+  const bytes = processedFileObject.getBytes();
+  const fileBase64 = Utilities.base64Encode(bytes);
+  const pdfDoc = await PDFDocument.load(fileBase64, { password, ignoreEncryption: true});
+  const unencrypted = await pdfDoc.save() as unknown as GoogleAppsScript.Byte[];
+  // the file that is stored is renamed later by the storeAttachment method
+  return Utilities.newBlob(unencrypted, 'application/pdf', 'temp_decrypted_name.pdf') as unknown as GoogleAppsScript.Gmail.GmailAttachment;
+}


### PR DESCRIPTION
# Description

This PR intends to add decryptPDF action. It will take attached pdfs, store the original and decrypted in the chosen location. 

It also adds new dependency `@cantoo/pdf-lib` fork that allows for pdf decrypting. This library uses promises, which makes decrypting the pdf async as well. The rest of the code is synchronous.

Fixes [#355)](https://github.com/ahochsteger/gmail-processor/issues/355)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [ ] Other type of change (test, build, refactoring, ...)

## How has this been tested?

Could take pwd protected file, decrypt it and then try to open without pwd. That plus similar test as for the store action.
TODO

- [ ] Test example A: [exampleA.js](src/test/examples/exampleA.js)
- [ ] ... (add more, if required or delete this line)

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
