### PR TITLE
fix(docs): resolve package-lock.json conflict for react-json-view-lite

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -16352,9 +16352,9 @@
       "license": "MIT"
     },
     "node_modules/react-json-view-lite": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/react-json-view-lite/-/react-json-view-lite-2.4.1.tgz",
-      "integrity": "sha512-fwFYknRIBxjbFm0kBDrzgBy1xa5tDg2LyXXBepC5f1b+MY3BUClMCsvanMPn089JbV1Eg3nZcrp0VCuH43aXnA==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/react-json-view-lite/-/react-json-view-lite-2.5.0.tgz",
+      "integrity": "sha512-tk7o7QG9oYyELWHL8xiMQ8x4WzjCzbWNyig3uexmkLb54r8jO0yH3WCWx8UZS0c49eSA4QUmG5caiRJ8fAn58g==",
       "license": "MIT",
       "engines": {
         "node": ">=18"

--- a/docs/package.json
+++ b/docs/package.json
@@ -33,7 +33,7 @@
     "react-toastify": "11.0.5"
   },
   "overrides": {
-    "react-json-view-lite": "2.4.1"
+    "react-json-view-lite": "2.5.0"
   },
   "devDependencies": {
     "@docusaurus/eslint-plugin": "3.9.2",


### PR DESCRIPTION
Updates `docs/package-lock.json` and `docs/package.json` to properly integrate `react-json-view-lite` v2.5.0 which caused the PR #536 to fail on `npm ci` during the `pr-build` workflow.

---
*PR created automatically by Jules for task [16919354881782065160](https://jules.google.com/task/16919354881782065160) started by @ahochsteger*