### PR TITLE
🧹 Refactor regex escaping into RegexUtils.escapeRegExp

### DIFF
--- a/src/lib/config/v1/V1ToV2Converter.ts
+++ b/src/lib/config/v1/V1ToV2Converter.ts
@@ -12,6 +12,7 @@ import {
   DEFAULT_GLOBAL_QUERY_NEWER_THAN,
   DEFAULT_GLOBAL_QUERY_PREFIX,
 } from "../ThreadMatchConfig"
+import { RegexUtils } from "../../utils/RegexUtils"
 import { V1Config, newV1Config } from "./V1Config"
 import { RequiredV1Rule } from "./V1Rule"
 
@@ -138,10 +139,9 @@ export class V1ToV2Converter {
         attachmentConfig.match.name = rule.filenameFromRegexp
       }
       if (rule.filenameFrom && rule.filenameTo) {
-        attachmentConfig.match.name = String(rule.filenameFrom).replace(
-          /[\\^$*+?.()|[\]{}]/g,
-          "\\$&",
-        ) // TODO: Validate this regex!
+        attachmentConfig.match.name = RegexUtils.escapeRegExp(
+          String(rule.filenameFrom),
+        )
       }
       attachmentConfig.actions.push({
         name: "attachment.store",

--- a/src/lib/e2e/E2E.ts
+++ b/src/lib/e2e/E2E.ts
@@ -12,6 +12,7 @@ import { V1Config } from "../config/v1/V1Config"
 import { V1ToV2Converter } from "../config/v1/V1ToV2Converter"
 import { GmailProcessor } from "../processors/GmailProcessor"
 import { PatternUtil } from "../utils/PatternUtil"
+import { RegexUtils } from "../utils/RegexUtils"
 import { E2EDefaults } from "./E2EDefaults"
 
 export type E2EGlobalConfig = {
@@ -396,7 +397,7 @@ export class E2E {
         let testRunConfig = testConfig.runConfig
         if (activeTestRunId) {
           const runConfigStr = JSON.stringify(testConfig.runConfig).replace(
-            new RegExp(E2EDefaults.EMAIL_SUBJECT_PREFIX.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "g"),
+            new RegExp(RegexUtils.escapeRegExp(E2EDefaults.EMAIL_SUBJECT_PREFIX), "g"),
             `${E2EDefaults.EMAIL_SUBJECT_PREFIX}[${activeTestRunId}] `
           )
           testRunConfig = JSON.parse(runConfigStr) as Config

--- a/src/lib/utils/RegexUtils.spec.ts
+++ b/src/lib/utils/RegexUtils.spec.ts
@@ -2,7 +2,7 @@ import { RegexUtils } from "./RegexUtils"
 
 describe("escapeRegExp()", () => {
   it("should escape special characters", () => {
-    expect(RegexUtils.escapeRegExp(".*+?^${}()|[\]\\")).toEqual(
+    expect(RegexUtils.escapeRegExp(".*+?^${}()|[]\\")).toEqual(
       "\\.\\*\\+\\?\\^\\$\\{\\}\\(\\)\\|\\[\\]\\\\",
     )
   })

--- a/src/lib/utils/RegexUtils.spec.ts
+++ b/src/lib/utils/RegexUtils.spec.ts
@@ -1,5 +1,19 @@
 import { RegexUtils } from "./RegexUtils"
 
+describe("escapeRegExp()", () => {
+  it("should escape special characters", () => {
+    expect(RegexUtils.escapeRegExp(".*+?^${}()|[\]\\")).toEqual(
+      "\\.\\*\\+\\?\\^\\$\\{\\}\\(\\)\\|\\[\\]\\\\",
+    )
+  })
+  it("should not escape non-special characters", () => {
+    expect(RegexUtils.escapeRegExp("abc123_ ")).toEqual("abc123_ ")
+  })
+  it("should handle empty string", () => {
+    expect(RegexUtils.escapeRegExp("")).toEqual("")
+  })
+})
+
 describe("matchRegExp()", () => {
   it("should match regex without modifier", () => {
     const matches = RegexUtils.matchRegExp("^test$", "test")

--- a/src/lib/utils/RegexUtils.spec.ts
+++ b/src/lib/utils/RegexUtils.spec.ts
@@ -2,7 +2,7 @@ import { RegexUtils } from "./RegexUtils"
 
 describe("escapeRegExp()", () => {
   it("should escape special characters", () => {
-    expect(RegexUtils.escapeRegExp(".*+?^${}()|[]\\")).toEqual(
+    expect(RegexUtils.escapeRegExp(".*+?^${}()|[\]\\")).toEqual(
       "\\.\\*\\+\\?\\^\\$\\{\\}\\(\\)\\|\\[\\]\\\\",
     )
   })

--- a/src/lib/utils/RegexUtils.ts
+++ b/src/lib/utils/RegexUtils.ts
@@ -7,7 +7,7 @@ export class RegexUtils {
    * @returns The escaped string.
    */
   public static escapeRegExp(str: string): string {
-    return str.replace(/[.*+?^${}()|[\\]\\-]/g, "\\$&")
+    return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
   }
 
   public static matchRegExp(

--- a/src/lib/utils/RegexUtils.ts
+++ b/src/lib/utils/RegexUtils.ts
@@ -7,7 +7,7 @@ export class RegexUtils {
    * @returns The escaped string.
    */
   public static escapeRegExp(str: string): string {
-    return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+    return str.replace(/[.*+?^${}()|[\\]\\-]/g, "\\$&")
   }
 
   public static matchRegExp(

--- a/src/lib/utils/RegexUtils.ts
+++ b/src/lib/utils/RegexUtils.ts
@@ -1,6 +1,15 @@
 import { ProcessingContext } from "../Context"
 
 export class RegexUtils {
+  /**
+   * Escapes special characters in a string to be used in a regular expression.
+   * @param str The string to escape.
+   * @returns The escaped string.
+   */
+  public static escapeRegExp(str: string): string {
+    return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+  }
+
   public static matchRegExp(
     regex: string,
     str: string | undefined,


### PR DESCRIPTION
Created `RegexUtils.escapeRegExp` in `src/lib/utils/RegexUtils.ts` and refactored `src/lib/config/v1/V1ToV2Converter.ts` and `src/lib/e2e/E2E.ts` to use it. Added unit tests for the new utility.

---
*PR created automatically by Jules for task [15140746189955771215](https://jules.google.com/task/15140746189955771215) started by @ahochsteger*