### PR TITLE
fix(scripts): resolve ReferenceError when publishing patch releases

### DIFF
--- a/scripts/release-manager.mjs
+++ b/scripts/release-manager.mjs
@@ -826,7 +826,7 @@ function publishDraft(tag) {
 async function announceInDiscussions(version, body) {
   const versionParts = version.replace(/^v/, "").split(".")
   const patch = parseInt(versionParts[2] || "0")
-  if (patch !== 0 && !publish) {
+  if (patch !== 0) {
     log(`SKIP: Community announcement for patch version ${version}`)
     return
   }


### PR DESCRIPTION
This PR fixes an issue where the CI pipeline failed to publish new release notes due to a `ReferenceError` for an undefined variable in the release manager script. 

The `scripts/release-manager.mjs` script was trying to check `if (patch !== 0 && !publish)` inside the `announceInDiscussions` function, but `publish` was never defined. The fix updates the condition to simply `if (patch !== 0)` which aligns with the intent to skip creating community announcements in GitHub discussions for patch releases.

---
*PR created automatically by Jules for task [16332245976916756157](https://jules.google.com/task/16332245976916756157) started by @ahochsteger*